### PR TITLE
Change DockerResolver to use container IP

### DIFF
--- a/docker_resolver.go
+++ b/docker_resolver.go
@@ -30,17 +30,15 @@ func (d *DockerResolver) Lookup(ctx context.Context, service string) ([]Endpoint
 	var endpoints []Endpoint
 	for _, container := range containers {
 		if svc, ok := container.Labels[DockerServiceLabel]; ok && svc == service {
-			var hostIp string
-			var hostPort int
-			for _, portData := range container.Ports {
-				if portData.PrivatePort == DockerServicePort {
-					hostIp = portData.IP
-					hostPort = portData.PublicPort
+			var containerIP string
+			for _, setting := range container.NetworkSettings.Networks {
+				if setting.IPAddress != "" {
+					containerIP = setting.IPAddress
+					break
 				}
-				break
 			}
 
-			addr, err := parseAddr(hostIp, hostPort)
+			addr, err := parseAddr(containerIP, DockerServicePort)
 			if err != nil {
 				continue
 			}

--- a/docker_resolver_test.go
+++ b/docker_resolver_test.go
@@ -141,7 +141,7 @@ func TestDockerResolver(t *testing.T) {
 		t.Log("got: ", len(endpoints))
 	}
 
-	addr := "0.0.0.0:3002"
+	addr := "172.20.0.3:3000"
 	if endpoints[0].Addr.String() != addr {
 		t.Error("unexpected endpoint")
 		t.Log("got: ", endpoints[0].Addr)


### PR DESCRIPTION
Due to the way we are configuring our Docker network on the EC2 instances, we have to use the container IP and so the service port. This PR fixes that.